### PR TITLE
Return account details

### DIFF
--- a/src/main/java/georgemarrows/learnspring/controller/AccountController.java
+++ b/src/main/java/georgemarrows/learnspring/controller/AccountController.java
@@ -1,7 +1,6 @@
 package georgemarrows.learnspring.controller;
 
 import georgemarrows.learnspring.domain.Customer;
-import georgemarrows.learnspring.domain.Transaction;
 import georgemarrows.learnspring.service.AccountService;
 import georgemarrows.learnspring.service.AccountService.AccountDetail;
 import georgemarrows.learnspring.service.CustomerService;
@@ -37,16 +36,23 @@ public class AccountController {
   }
 
   @GetMapping
-  public List<AccountDetail> get(@RequestParam String customerId) {
+  public AccountListResult get(@RequestParam String customerId) {
     logger.warn("GET /api/account received " + customerId);
 
-    // TODO remove this
-    // Another Endpoint will output the user information showing Name, Surname,
-    // balance, and transactions of the accounts.
-    // Customer c = customerService.findCustomer(customerId);
+    Customer c = customerService.findCustomer(customerId);
 
-    return accountService.listAccountsForCustomer(customerId);
+    return new AccountListResult(
+      c.firstName(),
+      c.surname(),
+      accountService.listAccountsForCustomer(customerId)
+    );
   }
+
+  public record AccountListResult(
+    String firstName,
+    String surname,
+    List<AccountDetail> accountDetails
+  ) {}
 
   @PostMapping
   public CreateAccountResult create(@RequestBody CreateAccountRequest account) {

--- a/src/main/java/georgemarrows/learnspring/controller/AccountController.java
+++ b/src/main/java/georgemarrows/learnspring/controller/AccountController.java
@@ -11,13 +11,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.server.ResponseStatusException;
 
 @RestController
 @RequestMapping("/api/account")
@@ -38,23 +38,26 @@ public class AccountController {
   }
 
   @GetMapping
-  public AccountListResult get(@RequestParam String customerId) {
+  public ResponseEntity<?> get(@RequestParam String customerId) {
     logger.warn("GET /api/account received " + customerId);
 
     Customer c = customerService.findCustomer(customerId);
 
     if (c == null) {
-      throw new ResponseStatusException(
-        HttpStatus.NOT_FOUND,
-        "Customer not found"
-      );
+      return ResponseEntity
+        .status(HttpStatus.NOT_FOUND)
+        .body("No customer found");
     }
 
-    return new AccountListResult(
-      c.firstName(),
-      c.surname(),
-      accountService.listAccountsForCustomer(customerId)
-    );
+    return ResponseEntity
+      .status(HttpStatus.OK)
+      .body(
+        new AccountListResult(
+          c.firstName(),
+          c.surname(),
+          accountService.listAccountsForCustomer(customerId)
+        )
+      );
   }
 
   public record AccountListResult(

--- a/src/main/java/georgemarrows/learnspring/controller/AccountController.java
+++ b/src/main/java/georgemarrows/learnspring/controller/AccountController.java
@@ -44,18 +44,18 @@ public class AccountController {
   public ResponseEntity<?> get(@RequestParam String customerId) {
     logger.warn("GET /api/account received " + customerId);
 
-    Customer c = customerService.findCustomer(customerId);
+    try {
+      var c = customerService.findCustomer(customerId);
+      var res = new AccountListResult(
+        c.firstName(),
+        c.surname(),
+        accountService.listAccountsForCustomer(customerId)
+      );
 
-    if (c == null) {
+      return ResponseEntity.status(HttpStatus.OK).body(res);
+    } catch (NoSuchCustomer e) {
       return ResponseEntity.status(HttpStatus.NOT_FOUND).body(NO_SUCH_CUSTOMER);
     }
-
-    var res = new AccountListResult(
-      c.firstName(),
-      c.surname(),
-      accountService.listAccountsForCustomer(customerId)
-    );
-    return ResponseEntity.status(HttpStatus.OK).body(res);
   }
 
   public record AccountListResult(

--- a/src/main/java/georgemarrows/learnspring/controller/AccountController.java
+++ b/src/main/java/georgemarrows/learnspring/controller/AccountController.java
@@ -10,12 +10,14 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
 @RestController
 @RequestMapping("/api/account")
@@ -40,6 +42,13 @@ public class AccountController {
     logger.warn("GET /api/account received " + customerId);
 
     Customer c = customerService.findCustomer(customerId);
+
+    if (c == null) {
+      throw new ResponseStatusException(
+        HttpStatus.NOT_FOUND,
+        "Customer not found"
+      );
+    }
 
     return new AccountListResult(
       c.firstName(),

--- a/src/main/java/georgemarrows/learnspring/controller/AccountController.java
+++ b/src/main/java/georgemarrows/learnspring/controller/AccountController.java
@@ -37,13 +37,7 @@ public class AccountController {
   }
 
   @GetMapping
-  public List<Transaction> get(@RequestParam String customerId) {
-    logger.warn("GET /api/account received " + customerId);
-    return accountService.listTransactions(Transaction.dummyFromAccountId);
-  }
-
-  @GetMapping("/new")
-  public List<AccountDetail> getNew(@RequestParam String customerId) {
+  public List<AccountDetail> get(@RequestParam String customerId) {
     logger.warn("GET /api/account received " + customerId);
 
     // TODO remove this
@@ -51,10 +45,7 @@ public class AccountController {
     // balance, and transactions of the accounts.
     // Customer c = customerService.findCustomer(customerId);
 
-    List<AccountDetail> accountDetails = accountService.listAccountsForCustomer(
-      customerId
-    );
-    return accountDetails;
+    return accountService.listAccountsForCustomer(customerId);
   }
 
   @PostMapping

--- a/src/main/java/georgemarrows/learnspring/controller/AccountController.java
+++ b/src/main/java/georgemarrows/learnspring/controller/AccountController.java
@@ -1,7 +1,9 @@
 package georgemarrows.learnspring.controller;
 
+import georgemarrows.learnspring.domain.Customer;
 import georgemarrows.learnspring.domain.Transaction;
 import georgemarrows.learnspring.service.AccountService;
+import georgemarrows.learnspring.service.AccountService.AccountDetail;
 import georgemarrows.learnspring.service.CustomerService;
 import georgemarrows.learnspring.service.CustomerService.CreateAccountResult;
 import java.math.BigDecimal;
@@ -38,6 +40,21 @@ public class AccountController {
   public List<Transaction> get(@RequestParam String customerId) {
     logger.warn("GET /api/account received " + customerId);
     return accountService.listTransactions(Transaction.dummyFromAccountId);
+  }
+
+  @GetMapping("/new")
+  public List<AccountDetail> getNew(@RequestParam String customerId) {
+    logger.warn("GET /api/account received " + customerId);
+
+    // TODO remove this
+    // Another Endpoint will output the user information showing Name, Surname,
+    // balance, and transactions of the accounts.
+    // Customer c = customerService.findCustomer(customerId);
+
+    List<AccountDetail> accountDetails = accountService.listAccountsForCustomer(
+      customerId
+    );
+    return accountDetails;
   }
 
   @PostMapping

--- a/src/main/java/georgemarrows/learnspring/domain/Customer.java
+++ b/src/main/java/georgemarrows/learnspring/domain/Customer.java
@@ -34,6 +34,14 @@ public class Customer {
     return id;
   }
 
+  public String firstName() {
+    return firstName;
+  }
+
+  public String surname() {
+    return surname;
+  }
+
   public Account createAccount() {
     // In reality, there will be a lot of extra info and checks here
     // - what type of account: current, or some kind of savings account?

--- a/src/main/java/georgemarrows/learnspring/repository/InMemoryAccountRepository.java
+++ b/src/main/java/georgemarrows/learnspring/repository/InMemoryAccountRepository.java
@@ -16,14 +16,6 @@ public class InMemoryAccountRepository implements AccountRepository {
   Map<String, Account> store = new HashMap<>();
   Map<String, Transaction> txnStore = new HashMap<>();
 
-  {
-    var txn = Transaction.newCrediting(
-      "YOURACCOUNT678",
-      BigDecimal.valueOf(100)
-    );
-    txnStore.put(txn.id(), txn);
-  }
-
   public Optional<Account> findById(String accountId) {
     return Optional.ofNullable(store.get(accountId));
   }

--- a/src/main/java/georgemarrows/learnspring/service/AccountService.java
+++ b/src/main/java/georgemarrows/learnspring/service/AccountService.java
@@ -1,7 +1,9 @@
 package georgemarrows.learnspring.service;
 
+import georgemarrows.learnspring.domain.Account;
 import georgemarrows.learnspring.domain.AccountRepository;
 import georgemarrows.learnspring.domain.Transaction;
+import java.util.ArrayList;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -22,4 +24,22 @@ public class AccountService {
     // TODO we don't have a good DDD home yet for fetching transactions
     return accountRepository.listTransactionsForAccount(accountId);
   }
+
+  public List<AccountDetail> listAccountsForCustomer(String customerId) {
+    List<AccountDetail> res = new ArrayList<>();
+    for (Account acc : accountRepository.listForCustomer(customerId)) {
+      String accountId = acc.id();
+      AccountDetail ad = new AccountDetail(
+        accountId,
+        listTransactions(accountId)
+      );
+      res.add(ad);
+    }
+    return res;
+  }
+
+  public record AccountDetail(
+    String accountId,
+    List<Transaction> transactions
+  ) {}
 }

--- a/src/main/java/georgemarrows/learnspring/service/AccountService.java
+++ b/src/main/java/georgemarrows/learnspring/service/AccountService.java
@@ -19,8 +19,6 @@ public class AccountService {
   }
 
   public List<Transaction> listTransactions(String accountId) {
-    // get account
-    // ask account for transactions
     // TODO we don't have a good DDD home yet for fetching transactions
     return accountRepository.listTransactionsForAccount(accountId);
   }

--- a/src/main/java/georgemarrows/learnspring/service/CustomerService.java
+++ b/src/main/java/georgemarrows/learnspring/service/CustomerService.java
@@ -30,8 +30,12 @@ public class CustomerService {
   public CreateAccountResult createAccount(
     String customerId,
     BigDecimal initialCredit
-  ) {
+  ) throws NoSuchCustomer {
     Customer c = getCustomer(customerId);
+    if (c == null) {
+      throw new NoSuchCustomer();
+    }
+
     Account a = c.createAccount();
     Transaction t = a.credit(initialCredit);
 
@@ -43,6 +47,8 @@ public class CustomerService {
     }
     return new CreateAccountResult(a.id());
   }
+
+  public class NoSuchCustomer extends Exception {}
 
   public record CreateAccountResult(String accountId) {}
 

--- a/src/main/java/georgemarrows/learnspring/service/CustomerService.java
+++ b/src/main/java/georgemarrows/learnspring/service/CustomerService.java
@@ -46,6 +46,10 @@ public class CustomerService {
 
   public record CreateAccountResult(String accountId) {}
 
+  public Customer findCustomer(String customerId) {
+    return getCustomer(customerId);
+  }
+
   private Customer getCustomer(String customerId) {
     // TODO throw proper exception
     return customerRepository.findById(customerId).orElseThrow();

--- a/src/main/java/georgemarrows/learnspring/service/CustomerService.java
+++ b/src/main/java/georgemarrows/learnspring/service/CustomerService.java
@@ -52,6 +52,6 @@ public class CustomerService {
 
   private Customer getCustomer(String customerId) {
     // TODO throw proper exception
-    return customerRepository.findById(customerId).orElseThrow();
+    return customerRepository.findById(customerId).orElse(null);
   }
 }

--- a/src/main/java/georgemarrows/learnspring/service/CustomerService.java
+++ b/src/main/java/georgemarrows/learnspring/service/CustomerService.java
@@ -32,10 +32,6 @@ public class CustomerService {
     BigDecimal initialCredit
   ) throws NoSuchCustomer {
     Customer c = getCustomer(customerId);
-    if (c == null) {
-      throw new NoSuchCustomer();
-    }
-
     Account a = c.createAccount();
     Transaction t = a.credit(initialCredit);
 
@@ -52,12 +48,13 @@ public class CustomerService {
 
   public record CreateAccountResult(String accountId) {}
 
-  public Customer findCustomer(String customerId) {
+  public Customer findCustomer(String customerId) throws NoSuchCustomer {
     return getCustomer(customerId);
   }
 
-  private Customer getCustomer(String customerId) {
-    // TODO throw proper exception
-    return customerRepository.findById(customerId).orElse(null);
+  private Customer getCustomer(String customerId) throws NoSuchCustomer {
+    return customerRepository
+      .findById(customerId)
+      .orElseThrow(() -> new NoSuchCustomer());
   }
 }

--- a/src/test/java/georgemarrows/learnspring/endtoend/EndToEndTest.java
+++ b/src/test/java/georgemarrows/learnspring/endtoend/EndToEndTest.java
@@ -22,23 +22,9 @@ public class EndToEndTest {
   private TestRestTemplate template;
 
   @Test
-  public void getAccount() throws Exception {
-    ResponseEntity<String> response = template.getForEntity(
-      "/api/account?customerId={custId}",
-      String.class,
-      "abcdef"
-    );
-
-    Map<String, Object>[] result = new ObjectMapper()
-      .readValue(response.getBody(), HashMap[].class);
-
-    assertThat(result[0].get("amount")).isEqualTo(100);
-  }
-
-  @Test
   public void getAccountDetails() throws Exception {
     ResponseEntity<String> response = template.getForEntity(
-      "/api/account/new?customerId={custId}",
+      "/api/account?customerId={custId}",
       String.class,
       "a fixed id for testing"
     );

--- a/src/test/java/georgemarrows/learnspring/endtoend/EndToEndTest.java
+++ b/src/test/java/georgemarrows/learnspring/endtoend/EndToEndTest.java
@@ -20,6 +20,8 @@ import org.springframework.http.ResponseEntity;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class EndToEndTest {
 
+  private static final String KNOWN_CUSTOMER_ID = "a fixed id for testing";
+
   @Autowired
   private TestRestTemplate template;
 
@@ -28,7 +30,7 @@ public class EndToEndTest {
     ResponseEntity<String> response = template.getForEntity(
       "/api/account?customerId={custId}",
       String.class,
-      "a fixed id for testing"
+      KNOWN_CUSTOMER_ID
     );
 
     Map<String, Object> result = new ObjectMapper()
@@ -61,7 +63,7 @@ public class EndToEndTest {
     var response = post(
       "/api/account",
       "customerId",
-      "a fixed id for testing",
+      KNOWN_CUSTOMER_ID,
       "initialCredit",
       "0"
     );

--- a/src/test/java/georgemarrows/learnspring/endtoend/EndToEndTest.java
+++ b/src/test/java/georgemarrows/learnspring/endtoend/EndToEndTest.java
@@ -3,6 +3,7 @@ package georgemarrows.learnspring.endtoend;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import org.json.JSONObject;
@@ -29,11 +30,16 @@ public class EndToEndTest {
       "a fixed id for testing"
     );
 
-    Map<String, Object>[] result = new ObjectMapper()
-      .readValue(response.getBody(), HashMap[].class);
+    Map<String, Object> result = new ObjectMapper()
+      .readValue(response.getBody(), HashMap.class);
 
-    // No accounts for this customer
-    assertThat(result.length).isEqualTo(0);
+    assertThat(result)
+      .extracting(
+        r -> r.get("firstName"),
+        r -> r.get("surname"),
+        r -> ((ArrayList) r.get("accountDetails")).size() // no accounts for this customer
+      )
+      .containsExactly("George", "Marrows", 0);
   }
 
   @Test

--- a/src/test/java/georgemarrows/learnspring/endtoend/EndToEndTest.java
+++ b/src/test/java/georgemarrows/learnspring/endtoend/EndToEndTest.java
@@ -53,7 +53,7 @@ public class EndToEndTest {
 
     assertThat(response)
       .extracting("statusCode", "body")
-      .containsExactly(HttpStatus.NOT_FOUND, "No customer found");
+      .containsExactly(HttpStatus.NOT_FOUND, "No such customer");
   }
 
   @Test
@@ -69,6 +69,21 @@ public class EndToEndTest {
     Map<String, Object> res = new ObjectMapper()
       .readValue(response.getBody(), HashMap.class);
     assertThat(res.get("accountId")).isNotNull();
+  }
+
+  @Test
+  public void createAccountNoSuchCustomer() throws Exception {
+    var response = post(
+      "/api/account",
+      "customerId",
+      "there isn't a customer with this id",
+      "initialCredit",
+      "0"
+    );
+
+    assertThat(response)
+      .extracting("statusCode", "body")
+      .containsExactly(HttpStatus.NOT_FOUND, "No such customer");
   }
 
   private ResponseEntity<String> post(String url, String... jsonBody)

--- a/src/test/java/georgemarrows/learnspring/endtoend/EndToEndTest.java
+++ b/src/test/java/georgemarrows/learnspring/endtoend/EndToEndTest.java
@@ -51,13 +51,9 @@ public class EndToEndTest {
       "there isn't a customer with this id"
     );
 
-    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
-    // TODO we should explain why this is a 404, but the reason isn't getting passed
-    // out, which seems contrary to https://stackoverflow.com/a/62824123/2102842
-    // Map<String, Object> result = new ObjectMapper()
-    //   .readValue(response.getBody(), HashMap.class);
-
-    // assertThat(result.get("message")).isEqualTo("Customer not found");
+    assertThat(response)
+      .extracting("statusCode", "body")
+      .containsExactly(HttpStatus.NOT_FOUND, "No customer found");
   }
 
   @Test

--- a/src/test/java/georgemarrows/learnspring/endtoend/EndToEndTest.java
+++ b/src/test/java/georgemarrows/learnspring/endtoend/EndToEndTest.java
@@ -36,6 +36,21 @@ public class EndToEndTest {
   }
 
   @Test
+  public void getAccountDetails() throws Exception {
+    ResponseEntity<String> response = template.getForEntity(
+      "/api/account/new?customerId={custId}",
+      String.class,
+      "a fixed id for testing"
+    );
+
+    Map<String, Object>[] result = new ObjectMapper()
+      .readValue(response.getBody(), HashMap[].class);
+
+    // No accounts for this customer
+    assertThat(result.length).isEqualTo(0);
+  }
+
+  @Test
   public void createAccount() throws Exception {
     var response = post(
       "/api/account",

--- a/src/test/java/georgemarrows/learnspring/endtoend/EndToEndTest.java
+++ b/src/test/java/georgemarrows/learnspring/endtoend/EndToEndTest.java
@@ -13,6 +13,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 
@@ -40,6 +41,23 @@ public class EndToEndTest {
         r -> ((ArrayList) r.get("accountDetails")).size() // no accounts for this customer
       )
       .containsExactly("George", "Marrows", 0);
+  }
+
+  @Test
+  public void getAccountDetailsNoSuchCustomer() throws Exception {
+    ResponseEntity<String> response = template.getForEntity(
+      "/api/account?customerId={custId}",
+      String.class,
+      "there isn't a customer with this id"
+    );
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    // TODO we should explain why this is a 404, but the reason isn't getting passed
+    // out, which seems contrary to https://stackoverflow.com/a/62824123/2102842
+    // Map<String, Object> result = new ObjectMapper()
+    //   .readValue(response.getBody(), HashMap.class);
+
+    // assertThat(result.get("message")).isEqualTo("Customer not found");
   }
 
   @Test

--- a/src/test/java/georgemarrows/learnspring/service/AccountServiceTest.java
+++ b/src/test/java/georgemarrows/learnspring/service/AccountServiceTest.java
@@ -1,0 +1,52 @@
+package georgemarrows.learnspring.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import georgemarrows.learnspring.domain.AccountRepository;
+import georgemarrows.learnspring.domain.Customer;
+import georgemarrows.learnspring.domain.CustomerRepository;
+import georgemarrows.learnspring.repository.InMemoryAccountRepository;
+import georgemarrows.learnspring.repository.InMemoryCustomerRepository;
+import java.math.BigDecimal;
+import org.junit.jupiter.api.Test;
+
+public class AccountServiceTest {
+
+  CustomerRepository customerRepository = new InMemoryCustomerRepository();
+  AccountRepository accountRepository = new InMemoryAccountRepository();
+  Customer c = Customer.newWithName("George", "Marrows");
+
+  {
+    customerRepository.save(c);
+  }
+
+  @Test
+  public void canListAccountsForCustomer() {
+    final BigDecimal amountToCredit = new BigDecimal(1000);
+
+    // Given a new account for a customer
+    CustomerService cs = new CustomerService(
+      customerRepository,
+      accountRepository
+    );
+    AccountService as = new AccountService(accountRepository);
+
+    var createAccountResult = cs.createAccount(c.id(), amountToCredit);
+
+    // When list the accounts
+    var acDetails = as.listAccountsForCustomer(c.id());
+
+    // Then account details are correct
+    // .. 1 account with correct id
+    assertThat(acDetails.size()).isEqualTo(1);
+
+    var acDetail = acDetails.get(0);
+    assertThat(acDetail.accountId()).isEqualTo(createAccountResult.accountId());
+
+    // .. 1 transaction with correct balance
+    assertThat(acDetail.transactions().size()).isEqualTo(1);
+
+    var txn = acDetail.transactions().get(0);
+    assertThat(txn.amount()).isEqualTo(amountToCredit);
+  }
+}

--- a/src/test/java/georgemarrows/learnspring/service/AccountServiceTest.java
+++ b/src/test/java/georgemarrows/learnspring/service/AccountServiceTest.java
@@ -21,7 +21,7 @@ public class AccountServiceTest {
   }
 
   @Test
-  public void canListAccountsForCustomer() {
+  public void canListAccountsForCustomer() throws Exception {
     final BigDecimal amountToCredit = new BigDecimal(1000);
 
     // Given a new account for a customer

--- a/src/test/java/georgemarrows/learnspring/service/AccountServiceTest.java
+++ b/src/test/java/georgemarrows/learnspring/service/AccountServiceTest.java
@@ -40,13 +40,12 @@ public class AccountServiceTest {
     // .. 1 account with correct id
     assertThat(acDetails.size()).isEqualTo(1);
 
-    var acDetail = acDetails.get(0);
-    assertThat(acDetail.accountId()).isEqualTo(createAccountResult.accountId());
-
-    // .. 1 transaction with correct balance
-    assertThat(acDetail.transactions().size()).isEqualTo(1);
-
-    var txn = acDetail.transactions().get(0);
-    assertThat(txn.amount()).isEqualTo(amountToCredit);
+    assertThat(acDetails.get(0))
+      .extracting(
+        ac -> ac.accountId(),
+        ac -> ac.transactions().size(),
+        ac -> ac.transactions().get(0).amount()
+      )
+      .containsExactly(createAccountResult.accountId(), 1, amountToCredit);
   }
 }

--- a/src/test/java/georgemarrows/learnspring/service/CustomerServiceTest.java
+++ b/src/test/java/georgemarrows/learnspring/service/CustomerServiceTest.java
@@ -58,7 +58,7 @@ public class CustomerServiceTest {
       accountRepository
     );
 
-    // When we create an account for the customer with zero balance
+    // When we create an account for the customer with non-zero balance
     cs.createAccount(c.id(), amountToCredit);
 
     // .. then an account is created

--- a/src/test/java/georgemarrows/learnspring/service/CustomerServiceTest.java
+++ b/src/test/java/georgemarrows/learnspring/service/CustomerServiceTest.java
@@ -24,7 +24,7 @@ public class CustomerServiceTest {
   }
 
   @Test
-  public void createAccountWithZeroBalance() {
+  public void createAccountWithZeroBalance() throws Exception {
     // Given
     CustomerService cs = new CustomerService(
       customerRepository,
@@ -49,7 +49,7 @@ public class CustomerServiceTest {
   }
 
   @Test
-  public void createAccountWithNonZeroBalance() {
+  public void createAccountWithNonZeroBalance() throws Exception {
     final BigDecimal amountToCredit = new BigDecimal(1000);
 
     // Given


### PR DESCRIPTION
### Previous behaviour
- GET /api/account only listed transactions for a fixed dummy account

### New behaviour
- Now it correctly lists accounts for a given `customerId`
- Also, error handling for both the GET and POST endpoints has been corrected to return a status code of 404

### Testing 
- Updated end-to-end tests for GET /api/account
- New unit test for `AccountService`

### Any outstanding issues
None
